### PR TITLE
Commit source code corresponding to version v0.1.25.2

### DIFF
--- a/public/component/libcamera_image/CMakeLists.txt
+++ b/public/component/libcamera_image/CMakeLists.txt
@@ -36,6 +36,7 @@ pkg_check_modules(LIBCAMERA REQUIRED libcamera)
 file(GLOB PUBLIC_HEADER_FILES
      ${PROJECT_SOURCE_DIR}/include/senscord/${OUTPUT_INCLUDE_DIR}/*.h)
 
+add_compile_options(-DIMX500_ISP_MANUAL_MODE_ON)
 # Create senscord.lib target.
 add_library(${TARGET_NAME} SHARED
             src/libcamera_image_stream_source_factory.cpp

--- a/public/component/libcamera_image/src/libcamera_image_stream_source.cpp
+++ b/public/component/libcamera_image/src/libcamera_image_stream_source.cpp
@@ -927,6 +927,11 @@ senscord::Status LibcameraImageStreamSource::Set(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Set(libcamera_image::"
                             "CameraExposureModeProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Set(libcamera_image::"
+                            "CameraExposureModeProperty) not supported");
+#else
   senscord::Status status;
 
   switch (property->mode) {
@@ -981,6 +986,7 @@ senscord::Status LibcameraImageStreamSource::Set(
   camera_exposure_mode_ = *property;
 
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Get(
@@ -990,8 +996,14 @@ senscord::Status LibcameraImageStreamSource::Get(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Get(libcamera_image::"
                             "CameraExposureModeProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Get(libcamera_image::"
+                            "CameraExposureModeProperty) not supported");
+#else
   *property = camera_exposure_mode_;
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Set(
@@ -1001,6 +1013,11 @@ senscord::Status LibcameraImageStreamSource::Set(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Set(libcamera_image::"
                             "CameraAutoExposureProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Set(libcamera_image::"
+                            "CameraAutoExposureProperty) not supported");
+#else
   senscord::Status status;
 
   CameraAutoExposureProperty camera_auto_exposure = *property;
@@ -1032,6 +1049,7 @@ senscord::Status LibcameraImageStreamSource::Set(
   }
 
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Get(
@@ -1041,6 +1059,11 @@ senscord::Status LibcameraImageStreamSource::Get(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Get(libcamera_image::"
                             "CameraAutoExposureProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Get(libcamera_image::"
+                            "CameraAutoExposureProperty) not supported");
+#else
   senscord::Status status;
 
   CameraAutoExposureProperty camera_auto_exposure;
@@ -1056,6 +1079,7 @@ senscord::Status LibcameraImageStreamSource::Get(
   *property = camera_auto_exposure;
 
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Set(
@@ -1065,6 +1089,11 @@ senscord::Status LibcameraImageStreamSource::Set(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Set(libcamera_image::"
                             "CameraEvCompensationProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Set(libcamera_image::"
+                            "CameraEvCompensationProperty) not supported");
+#else
   senscord::Status status;
 
   CameraEvCompensationProperty camera_ev_compensation = *property;
@@ -1076,6 +1105,7 @@ senscord::Status LibcameraImageStreamSource::Set(
   }
 
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Get(
@@ -1085,6 +1115,11 @@ senscord::Status LibcameraImageStreamSource::Get(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Get(libcamera_image::"
                             "CameraEvCompensationProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Get(libcamera_image::"
+                            "CameraEvCompensationProperty) not supported");
+#else
   senscord::Status status;
 
   CameraEvCompensationProperty camera_ev_compensation;
@@ -1097,6 +1132,7 @@ senscord::Status LibcameraImageStreamSource::Get(
 
   *property = camera_ev_compensation;
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Set(
@@ -1172,6 +1208,11 @@ senscord::Status LibcameraImageStreamSource::Set(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Set(libcamera_image::"
                             "CameraManualExposureProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Set(libcamera_image::"
+                            "CameraManualExposureProperty) not supported");
+#else
   senscord::Status status;
 
   // Validate gain per T4 behavior: reject NaN/Inf values
@@ -1204,6 +1245,7 @@ senscord::Status LibcameraImageStreamSource::Set(
   }
 
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Get(
@@ -1213,8 +1255,14 @@ senscord::Status LibcameraImageStreamSource::Get(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Get(libcamera_image::"
                             "CameraManualExposureProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Get(libcamera_image::"
+                            "CameraManualExposureProperty) not supported");
+#else
   *property = camera_manual_exposure_;
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Set(
@@ -1225,6 +1273,11 @@ senscord::Status LibcameraImageStreamSource::Set(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Set(libcamera_image::"
                             "CameraAutoExposureMeteringProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Set(libcamera_image::"
+                            "CameraAutoExposureMeteringProperty) not supported");
+#else
   senscord::Status status;
   AeMeteringWindow AeWindow;
 
@@ -1258,6 +1311,7 @@ senscord::Status LibcameraImageStreamSource::Set(
   camera_auto_exposure_metering_ = *property;
 
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Get(
@@ -1267,8 +1321,14 @@ senscord::Status LibcameraImageStreamSource::Get(
   SENSCORD_LOG_DEBUG_TAGGED("libcamera",
                             "LibcameraImageStreamSource::Get(libcamera_image::"
                             "CameraAutoExposureMeteringProperty)");
+#ifdef IMX500_ISP_MANUAL_MODE_ON
+  return SENSCORD_STATUS_FAIL("libcamera", senscord::Status::kCauseNotSupported,
+                              "LibcameraImageStreamSource::Get(libcamera_image::"
+                            "CameraAutoExposureMeteringProperty) not supported");
+#else
   *property = camera_auto_exposure_metering_;
   return senscord::Status::OK();
+#endif
 }
 
 senscord::Status LibcameraImageStreamSource::Set(

--- a/public/component/libcamera_image/src/rpicam_app_adapter.h
+++ b/public/component/libcamera_image/src/rpicam_app_adapter.h
@@ -315,6 +315,7 @@ class LibcameraAdapter {
   bool SetConvergenceSpeed(void);
   bool UpdateAutoExposureParam(void);
   bool UpdateManualExposureParam(void);
+  bool UpdateAntiFlickerMode(void);
   bool GetMaxExposureTime(uint32_t &max_exposure_time);
   bool GetMinExposureTime(uint32_t &min_exposure_time);
   bool GetMaxGain(float &max_gain);
@@ -390,6 +391,7 @@ class LibcameraAdapter {
   float isp_frame_rate_;
   AeMeteringMode ae_metering_mode_;
   AeMeteringWindow ae_metering_window_;
+  AeAntiFlickerMode ae_anti_flicker_mode_;
   float ev_compensation_;
   std::vector<float> ev_array_ = {0.0f, 0.25f, 0.5f, 0.75f, 1.0f, 1.25f, 1.5f};
   std::vector<SupportedIspParam> supported_isp_params_;


### PR DESCRIPTION
### Update included:
- Temporary fix for a white balance issue on Raspberry Pi's ISP. As a result, the following properties have been disabled:
  - CameraExposureModeProperty (auto mode is now always used)
  - CameraAutoExposureProperty (min/max exposure time, max gain, convergence speed)
  - CameraManualExposureProperty (exposure time, gain)
  - CameraEvCompensationProperty
  - CameraAutoExposureMeteringProperty